### PR TITLE
feat: support message pin when creating lottery (#4)

### DIFF
--- a/commands_args.go
+++ b/commands_args.go
@@ -422,6 +422,7 @@ func CmdCreateLottery(m *tb.Message) {
 	// :consume=n|y
 	// :num=1|100
 	// :draw=manual|>num
+	// :pin=y|n
 	if IsGroupAdminMiaoKo(m.Chat, m.Sender) {
 		payload, ah := ArgParse(m.Payload)
 		limit, _ := ah.Int("limit")
@@ -438,11 +439,18 @@ func CmdCreateLottery(m *tb.Message) {
 		if participant < num {
 			participant = 0
 		}
+		pin, setPin := ah.Bool("pin")
+		if !setPin {
+			pin = true
+		}
 
 		li := CreateLottery(m.Chat.ID, payload, limit, consume, num, duration, participant)
 
 		if li != nil {
-			li.UpdateTelegramMsg()
+			msg := li.UpdateTelegramMsg()
+			if msg != nil && pin {
+				Bot.Pin(msg)
+			}
 		} else {
 			SmartSendDelete(m, Locale("system.unexpected", m.Sender.LanguageCode))
 		}


### PR DESCRIPTION
增加对 #4 中抽奖时置顶消息的功能支持，同时提供 :pin=y|n 作为参数，默认为 y。