### PR TITLE
feat: support customize reply

### DIFF
--- a/api.go
+++ b/api.go
@@ -87,11 +87,12 @@ func InitRESTServer(portNum int, token string) {
 
 			if ci := GinParseGroupAndUser(c); ci != nil {
 				consumeRequest := struct {
-					Credit int64 `json:"credit,omitempty"`
+					Credit        int64 `json:"credit,omitempty"`
+					AllowNegative bool  `json:"allowNegative,omitempty"`
 				}{}
 				c.BindJSON(&consumeRequest)
 				if consumeRequest.Credit > 0 {
-					if ci.Credit >= consumeRequest.Credit {
+					if ci.Credit >= consumeRequest.Credit || (ci.Credit > 0 && consumeRequest.AllowNegative) {
 						ci = UpdateCredit(ci, UMAdd, -consumeRequest.Credit)
 						c.JSON(http.StatusOK, GinData(ci))
 					} else {

--- a/commands_args.go
+++ b/commands_args.go
@@ -347,7 +347,7 @@ func CmdSetAntiSpoiler(m *tb.Message) {
 			}
 
 			gc.AntiSpoiler = status
-			SetGroupConfig(m.Chat.ID, gc)
+			gc.Save()
 			SmartSendDelete(m, fmt.Sprintf(Locale("spoiler.success", GetSenderLocale(m)), gc.AntiSpoiler), &tb.SendOptions{
 				ParseMode:             "Markdown",
 				DisableWebPagePreview: true,
@@ -377,7 +377,7 @@ func CmdSetChannel(m *tb.Message) {
 				gc.MustFollow = ""
 				gc.MustFollowOnJoin = false
 				gc.MustFollowOnMsg = false
-				SetGroupConfig(m.Chat.ID, gc)
+				gc.Save()
 				SmartSendDelete(m, Locale("channel.set.cancel", GetSenderLocale(m)))
 			} else {
 				if UserIsInGroup(groupName, Bot.Me.ID) != UIGIn {
@@ -394,7 +394,7 @@ func CmdSetChannel(m *tb.Message) {
 						gc.MustFollowOnJoin = true
 						gc.MustFollowOnMsg = true
 					}
-					SetGroupConfig(m.Chat.ID, gc)
+					gc.Save()
 					SmartSendDelete(m, fmt.Sprintf(Locale("channel.set.success", GetSenderLocale(m)), gc.MustFollowOnJoin, gc.MustFollowOnMsg), &tb.SendOptions{
 						ParseMode:             "Markdown",
 						DisableWebPagePreview: true,
@@ -420,7 +420,7 @@ func CmdSetLocale(m *tb.Message) {
 				} else {
 					gc.Locale = payloads[0]
 				}
-				SetGroupConfig(m.Chat.ID, gc)
+				gc.Save()
 				SmartSendDelete(m, fmt.Sprintf(Locale("locale.set", GetSenderLocale(m)), gc.Locale))
 			} else {
 				SmartSendDelete(m, fmt.Sprintf(Locale("locale.get", GetSenderLocale(m)), gc.Locale))

--- a/commands_callback.go
+++ b/commands_callback.go
@@ -35,7 +35,8 @@ func CmdOnCallback(c *tb.Callback) {
 		joinVerificationId := fmt.Sprintf("join,%d,%d", gid, uid)
 		isGroupAdmin := IsGroupAdmin(m.Chat, c.Sender)
 		isMiaoGroupAdmin := IsGroupAdminMiaoKo(m.Chat, c.Sender)
-		if strings.Contains("vt unban kick check rp lt", cmd) && IsGroup(gid) && uid > 0 {
+		isUserRelatedOp := IsGroup(gid) && uid > 0
+		if isUserRelatedOp && strings.Contains("vt unban kick check rp lt", cmd) {
 			if cmd == "unban" && isGroupAdmin {
 				if Unban(gid, uid, 0) == nil {
 					Rsp(c, "cb.unban.success")
@@ -191,6 +192,12 @@ func CmdOnCallback(c *tb.Callback) {
 				}
 			} else {
 				Rsp(c, "cb.notAdmin")
+			}
+		} else if strings.Contains("close ", cmd) {
+			if cmd == "close" {
+				Bot.Delete(m)
+			} else {
+				Rsp(c, "cb.notParsed")
 			}
 		} else {
 			Rsp(c, "cb.notParsed")

--- a/constant.go
+++ b/constant.go
@@ -1,5 +1,5 @@
 package main
 
 var (
-	version = "1.5.0"
+	version = "1.6.0"
 )

--- a/locale.go
+++ b/locale.go
@@ -10,6 +10,7 @@ var LocaleAlias = map[string]string{
 var LocaleMap = map[string]map[string]string{
 	"zh": {
 		"system.unexpected": "❌ 无法完成任务，请检查服务器错误日志",
+		"system.notsend":    "❌ 发送消息失败",
 
 		"cmd.zc.notAllowed":  "当前群组不允许互相臭嘴哦 ~",
 		"cmd.zc.indeed":      "确实",
@@ -149,7 +150,8 @@ var LocaleMap = map[string]map[string]string{
 		"cb.disabled":                     "❌ 这个群组还没有被授权哦 ~",
 	},
 	"en": {
-		"system.unexpected": "❌ cannot fulfill the task, please check logs",
+		"system.unexpected": "❌ Cannot fulfill the task, please check logs",
+		"system.notsend":    "❌ Cannot send the message",
 
 		"cmd.zc.notAllowed":  "嘴臭 is not permitted in this group",
 		"cmd.zc.indeed":      "INDEED",

--- a/main.go
+++ b/main.go
@@ -39,11 +39,11 @@ func main() {
 		DErrorE(err, "Database Error | Cannot initialize database.")
 		os.Exit(1)
 	}
-	DInfo("Database Init | Database is initialzed.")
+	DInfo("System | Database is initialzed.")
 
 	InitTables()
 	ReadConfigs()
-	DInfo("Configuration Init | Config is initialzed.")
+	DInfo("System | Config is initialzed.")
 
 	if setadmin > 0 {
 		UpdateAdmin(setadmin, UMSet)
@@ -53,6 +53,9 @@ func main() {
 	InitTelegram()
 	if APIBind > 0 {
 		InitRESTServer(APIBind, APIToken)
+	}
+	if APIToken != "" {
+		DInfo("System | X-MiaoKeeper-Sign: " + SignHeader())
 	}
 
 	<-MakeSysChan()

--- a/memutils/lazyScheduler.go
+++ b/memutils/lazyScheduler.go
@@ -67,7 +67,7 @@ func (ls *LazyScheduler) Recover() {
 			counter += 1
 		}
 	}
-	Log(os.Stdout, fmt.Sprintf("Lazy Scheduler | Recovered %d tasks from cache\n", counter))
+	Log(os.Stdout, fmt.Sprintf("System | Recovered %d tasks from cache\n", counter))
 }
 
 func (ls *LazyScheduler) After(duration time.Duration, call *LazySchedulerCall) {

--- a/telebot.go
+++ b/telebot.go
@@ -171,12 +171,12 @@ func InitTelegram() {
 	go Bot.Start()
 
 	if !PingArg {
-		DInfo("MiaoKeeper is up.")
+		DInfo("System | MiaoKeeper bot is up.")
 		lazyScheduler.Recover()
 	}
 
 	if CleanArg {
-		DInfo("Clean mode is on.")
+		DInfo("System | Clean mode is on.")
 	}
 }
 


### PR DESCRIPTION
- [x] 支持自定义消息回复
- [x] 支持多种定义范式（回复消息、分数增减、回复按钮、回调函数等等）
- [x] 支持 API 强制扣分

```json
{
  "CustomReply": [{
    "Match": "^晚安$",
    "Name": "晚安测试",
    "Limit": -1,
    "CreditBehavior": 0,
    "ReplyMessage": "🌛 [{{UserName}}]({{UserLink}})，晚安宝贝～",
    "ReplyButtons": ["❌ 关闭|close"]
  }]
}
```

其中可以用于替换的 slug 有 `{{UserName}}`, `{{UserLink}}`, `{{UserID}}`, `{{ChatName}}`，
按钮为一个数组，数组的长度代表按钮行数，同一行多个按钮用 `||` 切割，展示与data用 `|` 切割，例如：

```json
["🙆 确认|close||❌ 关闭|close"]
```

表示一行显示两个按钮，点击后都会删除消息。data 的调用范式为两种：

- MiaoKeeper 函数，暂时不在这里赘述，这里只提供 `close` 作为参考
- 连接，如果 `|` 后面跟随 `https://xxx`，`http://xxx`，`tg://xxx` 之类的链接，则自动转换为跳转按钮