### PR TITLE
refactor: use CreditInfo micro lock instead of global lock

### DIFF
--- a/commands_events.go
+++ b/commands_events.go
@@ -103,7 +103,7 @@ func CmdOnUserLeft(m *tb.Message) {
 	gc := GetGroupConfig(m.Chat.ID)
 	if gc != nil && m.UserLeft.ID > 0 {
 		gc.UpdateAdmin(m.UserLeft.ID, UMDel)
-		UpdateCredit(BuildCreditInfo(m.Chat.ID, m.UserLeft, false), UMDel, 0, OPByCleanUp, m.UserLeft.ID, "UserLeft")
+		UpdateCredit((&UserInfo{}).From(m.Chat.ID, m.UserLeft), UMDel, 0, OPByCleanUp, m.UserLeft.ID, "UserLeft")
 	}
 	LazyDelete(m)
 }
@@ -117,7 +117,7 @@ func CmdOnChatMember(ctx tb.Context) error {
 			if cmu.NewChatMember.Role == tb.Kicked ||
 				cmu.NewChatMember.Role == tb.Left {
 				gc.UpdateAdmin(user.ID, UMDel)
-				UpdateCredit(BuildCreditInfo(cmu.Chat.ID, user, false), UMDel, 0, OPByCleanUp, user.ID, "UserKicked")
+				UpdateCredit((&UserInfo{}).From(cmu.Chat.ID, user), UMDel, 0, OPByCleanUp, user.ID, "UserKicked")
 			}
 		}
 	})

--- a/commands_helper.go
+++ b/commands_helper.go
@@ -321,7 +321,7 @@ func addCredit(chatId int64, user *tb.User, credit int64, force bool, reason OPR
 	if gc != nil && user != nil && user.ID > 0 && credit != 0 {
 		token := fmt.Sprintf("ac-%d-%d", chatId, user.ID)
 		if force || creditomap.AddBy(token, int(credit)) <= int(gc.CreditMapping.HourlyUpperBound) {
-			return UpdateCredit(BuildCreditInfo(chatId, user, false), UMAdd, credit, reason, executor, notes)
+			return UpdateCredit((&UserInfo{}).From(chatId, user), UMAdd, credit, reason, executor, notes)
 		}
 	}
 	return nil
@@ -337,16 +337,6 @@ func ValidMessageUser(m *tb.Message) bool {
 
 func ValidUser(u *tb.User) bool {
 	return u != nil && u.ID > 0 && !u.IsBot && u.ID != 777000 && u.Username != "Channel_Bot" && u.Username != "GroupAnonymousBot" && u.Username != "Telegram"
-}
-
-func BuildCreditInfo(groupId int64, user *tb.User, autoFetch bool) *CreditInfo {
-	ci := &CreditInfo{
-		user.ID, user.Username, GetUserName(user), 0, groupId,
-	}
-	if autoFetch {
-		ci.Credit = GetCredit(groupId, user.ID).Credit
-	}
-	return ci
 }
 
 func SmartEdit(to *tb.Message, what interface{}, options ...interface{}) (*tb.Message, error) {

--- a/constant.go
+++ b/constant.go
@@ -1,5 +1,5 @@
 package main
 
 var (
-	version = "1.12.0"
+	version = "1.13.0"
 )

--- a/database.go
+++ b/database.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/BBAlliance/miaokeeper/memutils"
+	"github.com/bep/debounce"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -96,6 +97,16 @@ type CreditInfo struct {
 	Name     string `json:"nickname" gorm:"column:name;type:text;not null"`
 	Credit   int64  `json:"credit" gorm:"column:credit;not null"`
 	GroupId  int64  `json:"groupId" gorm:"-"`
+
+	updateLock      sync.Mutex   `json:"-" gorm:"-"`
+	updateDebouncer func(func()) `json:"-" gorm:"-"`
+}
+
+type UserInfo struct {
+	Group    int64
+	ID       int64
+	Username string
+	Name     string
 }
 
 // GORM:%NAME%_Credit_Log_%GROUP%
@@ -293,19 +304,6 @@ func UpdateGroup(groupId int64, method UpdateMethod) bool {
 	return changed
 }
 
-func GetCredit(groupId, userId int64) *CreditInfo {
-	ret := &CreditInfo{}
-	realGroup := GetAliasedGroup(groupId)
-	err := DB.Table(DBTName("Credit", realGroup)).First(&ret, "userid = ?", userId).Error
-	if err != nil {
-		DLogf("Database Credit Read Error | gid=%d rgid=%d uid=%d error=%s", groupId, realGroup, userId, err.Error())
-	}
-	if ret.ID == userId {
-		ret.GroupId = groupId
-	}
-	return ret
-}
-
 func GetCreditRank(groupId int64, limit int) []*CreditInfo {
 	returns := []*CreditInfo{}
 	realGroup := GetAliasedGroup(groupId)
@@ -340,6 +338,10 @@ func FlushCredits(groupId int64, records [][]string, executor int64) {
 	if len(records) == 0 {
 		return
 	}
+
+	// TODO: 需要清除所有 CreditInfoCache 防止脏写入
+	creditInfoWritingLock.Lock()
+	defer creditInfoWritingLock.Unlock()
 
 	batches := []CreditInfo{}
 	logbatches := []CreditLog{}
@@ -392,54 +394,120 @@ func QueryLogs(groupId int64, offset uint64, limit uint64, uid int64, before tim
 	return ret
 }
 
-func UpdateCredit(user *CreditInfo, method UpdateMethod, value int64, reason OPReasons, executor int64, notes string) *CreditInfo {
-	ci := GetCredit(user.GroupId, user.ID)
-	if user.Name == "" {
-		user.Name = ci.Name
-	}
-	if user.Username == "" {
-		user.Username = ci.Username
-	}
-	user.Credit = ci.Credit
-	if method == UMSet {
-		user.Credit = value
-	} else if method == UMAdd {
-		user.Credit += value
-	} else if method == UMDel {
-		user.Credit = 0
+func (ui *UserInfo) From(groupId int64, user *tb.User) *UserInfo {
+	ui.ID = user.ID
+	ui.Name = GetQuotableUserName(user)
+	ui.Username = user.Username
+	ui.Group = groupId
+	return ui
+}
+
+var CreditInfoCache *ObliviousMapIfce
+
+func (ci *CreditInfo) Acquire(fn func()) {
+	ci.updateLock.Lock()
+	defer ci.updateLock.Unlock()
+
+	fn()
+}
+
+func (ci *CreditInfo) unsafeSync() {
+	if ci.updateDebouncer == nil {
+		ci.updateDebouncer = debounce.New(time.Second)
 	}
 
-	var err error
-	realGroup := GetAliasedGroup(user.GroupId)
-	if method != UMDel {
-		err = DB.Table(DBTName("Credit", realGroup)).Clauses(clause.OnConflict{
+	ci.updateDebouncer(func() {
+		if err := DB.Table(DBTName("Credit", ci.GroupId)).Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "userid"}},
 			DoUpdates: clause.AssignmentColumns([]string{"name", "username", "credit"}),
-		}).Create(&user).Error
-		DB.Table(DBTName("Credit_Log", realGroup)).Create(&CreditLog{
-			UserID:   user.ID,
-			Credit:   value,
-			Reason:   reason,
-			Executor: executor,
-			Notes:    notes,
-		})
-	} else if realGroup == user.GroupId {
-		// when the method is UMDel, do not delete aliased credit
-		err = DB.Table(DBTName("Credit", realGroup)).Delete(&user).Error
-		DB.Table(DBTName("Credit_Log", realGroup)).Create(&CreditLog{
-			UserID:   user.ID,
-			Credit:   -ci.Credit,
-			Reason:   reason,
-			Executor: executor,
-			Notes:    notes,
-		})
-	}
-	if err != nil {
-		DErrorE(err, "Database Credit Update Error")
+		}).Create(&ci).Error; err != nil {
+			DErrorE(err, "Database Credit Update Error")
+		}
+	})
+}
+
+func (ci *CreditInfo) unsafeUpdate(method UpdateMethod, value int64, ui *UserInfo, reason OPReasons, executor int64, notes string) *CreditInfo {
+	if ci == nil || ci.ID <= 0 {
+		return nil
 	}
 
-	DLogf("Update Credit | gid=%d rgid=%d user=%d alter=%d credit=%d", user.GroupId, realGroup, user.ID, method, value)
-	return user
+	// update user info
+	if ui != nil {
+		ci.Name = ui.Name
+		ci.Username = ui.Username
+	}
+
+	// prepare log
+	logCredit := value
+	if method == UMDel {
+		logCredit = -ci.Credit
+	}
+
+	// update credit
+	if method == UMSet {
+		ci.Credit = value
+	} else if method == UMAdd {
+		ci.Credit += value
+	} else if method == UMDel {
+		ci.Credit = 0
+	}
+
+	// flush log
+	if err := DB.Table(DBTName("Credit_Log", ci.GroupId)).Create(&CreditLog{
+		UserID:   ci.ID,
+		Credit:   logCredit,
+		Reason:   reason,
+		Executor: executor,
+		Notes:    notes,
+	}).Error; err != nil {
+		DErrorE(err, "Database Credit Log Update Error")
+	}
+
+	DLogf("Update Credit | gid=%d user=%d alter=%d credit=%d", ci.GroupId, ci.ID, method, value)
+	ci.unsafeSync()
+	return ci
+}
+
+func (ci *CreditInfo) Update(method UpdateMethod, value int64, ui *UserInfo, reason OPReasons, executor int64, notes string) *CreditInfo {
+	if ci == nil {
+		return nil
+	}
+
+	ci.updateLock.Lock()
+	defer ci.updateLock.Unlock()
+	return ci.unsafeUpdate(method, value, ui, reason, executor, notes)
+}
+
+var creditInfoWritingLock sync.Mutex
+
+func GetCreditInfo(groupId, userId int64) *CreditInfo {
+	groupId = GetAliasedGroup(groupId)
+	cicKey := fmt.Sprintf("%d-%d", groupId, userId)
+	if cii, ok := CreditInfoCache.Get(cicKey); ok && cii != nil {
+		if ci, ok := cii.(*CreditInfo); ok && ci != nil {
+			return ci
+		}
+	}
+
+	creditInfoWritingLock.Lock()
+	defer creditInfoWritingLock.Unlock()
+
+	ret := &CreditInfo{}
+	err := DB.Table(DBTName("Credit", groupId)).First(&ret, "userid = ?", userId).Error
+	if err != nil {
+		DLogf("Database Credit Read Error | gid=%d uid=%d error=%s", groupId, userId, err.Error())
+	}
+
+	if ret.ID == userId {
+		ret.GroupId = groupId
+		CreditInfoCache.Set(cicKey, ret)
+	}
+	return ret
+}
+
+func UpdateCredit(ui *UserInfo, method UpdateMethod, value int64, reason OPReasons, executor int64, notes string) *CreditInfo {
+	ci := GetCreditInfo(ui.Group, ui.ID)
+	return ci.Update(method, value, ui, reason, executor, notes)
 }
 
 // status: -1 not start, 0 start, 1 stopped, 2 finished
@@ -709,4 +777,8 @@ func CreateLottery(groupId int64, payload string, limit int, consume bool, num i
 func init() {
 	GroupConfigCache = make(map[int64]*GroupConfig)
 	LotteryConfigCache = make(map[string]*LotteryInstance)
+
+	memdriver := &memutils.MemDriverMemory{}
+	memdriver.Init()
+	CreditInfoCache = NewOMapIfce("cicache/", time.Hour, true, memdriver)
 }

--- a/telebot.go
+++ b/telebot.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/BBAlliance/miaokeeper/memutils"
@@ -48,8 +47,6 @@ var redpacketcaptcha *ObliviousMapStr
 
 var debouncer func(func())
 var lazyScheduler *memutils.LazyScheduler
-
-var usercreditlock sync.Mutex
 
 var DefaultWarnKeywords = []string{"口臭", "口 臭", "口  臭", "口臭!", "口臭！", "嘴臭", "嘴 臭", "嘴  臭", "嘴臭!", "嘴臭！"}
 var DefaultBanKeywords = []string{"恶意广告", "惡意廣告", "恶意发言", "惡意發言", "恶意举报", "惡意舉報", "惡意檢舉", "恶意嘴臭", "恶意口臭"}


### PR DESCRIPTION
> 使用 CreditInfo 局部锁来处理分数不一致性问题，避免使用全局锁，以提升性能

### 解决的问题
- [x] 取消全局锁，提升性能
- [x] 支持 `ci.Acquire` 来暂时冻结分数增加从而保证一致性
- [x] 限制刷写频率为 100ms 防止极端条件下受数据库连接速度瓶颈限制
- [x] 用懒等待处理+锁的方法解决批量刷写时带来的不一致问题
- [x] 解除 API / Transfer / DrawLottery 共用一个锁导致的大规模性能下降
